### PR TITLE
Update comp.sh

### DIFF
--- a/11_mi_light/comp.sh
+++ b/11_mi_light/comp.sh
@@ -1,2 +1,2 @@
-g++ -Ofast -mfpu=vfp -mfloat-abi=hard -march=ARMv7-A -mtune=ARM1176JZF-S -I /usr/local/include -L /usr/local/lib -lrf24-bcm PL1167_nRF24.cpp MiLightRadio.cpp openmili.cpp -o openmilight
-g++ -Ofast -mfpu=vfp -mfloat-abi=hard -march=ARMv7-A -mtune=ARM1176JZF-S -I /usr/local/include -L /usr/local/lib -lrf24-bcm PL1167_nRF24.cpp MiLightRadio.cpp send_cmd.cpp -o send_cmd
+g++ -Ofast -mfpu=vfp -mfloat-abi=hard -march=armv7-a -mtune=arm1176jzf-s -I /usr/local/include -L /usr/local/lib -lrf24-bcm PL1167_nRF24.cpp MiLightRadio.cpp openmili.cpp -o openmilight
+g++ -Ofast -mfpu=vfp -mfloat-abi=hard -march=armv7-a -mtune=arm1176jzf-s -I /usr/local/include -L /usr/local/lib -lrf24-bcm PL1167_nRF24.cpp MiLightRadio.cpp send_cmd.cpp -o send_cmd


### PR DESCRIPTION
Hi Simon, thanks for putting together the Mi Light walkthrough in MagPi 41. I'm following it and found that I had to update -march and -mtune to be lowercase to get the comp.sh to execute without errors. Without the change I got the following errors:

cc1plus: error: bad value (ARMv7-A) for -march switch
cc1plus: error: bad value (ARM1176JZF-S) for -mtune switch

I checked here and also found the code to be in lowercase: http://torsten-traenkner.de/wissen/smarthome/openmilight.php

Regards

Chris
